### PR TITLE
解决使用MiPush模块通知应用名称重复

### DIFF
--- a/xposed/src/main/java/one/yufz/hmspush/hook/hms/HookPushNC.kt
+++ b/xposed/src/main/java/one/yufz/hmspush/hook/hms/HookPushNC.kt
@@ -36,6 +36,18 @@ object HookPushNC {
 
 //        PushSignWatcher.watch()
 
+        val notificationController = classLoader.findClass("com.xiaomi.xmsf.push.notification.NotificationController")
+
+        notificationController.hookMethod(
+                "isMiPushInstalled"
+        ) {
+            replace(hookCheck) {
+                tryInvoke {
+                    return@replace true
+                }
+            }
+        }
+
         val classNotificationManager = classLoader.findClass(TargetClass)
 
         //notify(


### PR DESCRIPTION
解决 https://github.com/NihilityT/MiPushFramework/issues/27 的问题
与 https://github.com/NihilityT/MiPushFramework/pull/28 搭配