### PR TITLE
feat: do not log '[MiPush]  Common  forName' on release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ ext {
     gitVersionName = getVersionName()
     APPLICATION_ID = "com.nihility.mipush"
 
-    COMPILE_SDK = 33
+    COMPILE_SDK = 34
     MIN_SDK = 26
-    TARGET_SDK = 33
+    TARGET_SDK = 34
 }

--- a/xposed/build.gradle
+++ b/xposed/build.gradle
@@ -13,6 +13,9 @@ android {
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
+        buildFeatures {
+            buildConfig true
+        }
     }
 
     buildTypes {

--- a/xposed/src/main/java/one/yufz/hmspush/hook/fakedevice/Common.kt
+++ b/xposed/src/main/java/one/yufz/hmspush/hook/fakedevice/Common.kt
@@ -4,6 +4,7 @@ import de.robv.android.xposed.callbacks.XC_LoadPackage
 import one.yufz.hmspush.hook.XLog
 import one.yufz.xposed.hookMethod
 import miui.external.SdkHelper
+import one.yufz.hmspush.xposed.BuildConfig
 
 open class Common : IFakeDevice {
     companion object {
@@ -46,7 +47,9 @@ open class Common : IFakeDevice {
                     XLog.d(TAG, "forHook $requestClass")
                     result = returnClass
                 } else {
-                    XLog.d(TAG, "forName $requestClass")
+                    if (BuildConfig.DEBUG) {
+                        XLog.d(TAG, "forName $requestClass")
+                    }
                 }
             }
         }

--- a/xposed/src/main/java/one/yufz/hmspush/hook/hms/PushSignWatcher.kt
+++ b/xposed/src/main/java/one/yufz/hmspush/hook/hms/PushSignWatcher.kt
@@ -24,7 +24,7 @@ object PushSignWatcher : SharedPreferences.OnSharedPreferenceChangeListener {
         pushSignPref.registerOnSharedPreferenceChangeListener(this)
     }
 
-    override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences, key: String) {
+    override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences, key: String?) {
         XLog.d(TAG, "onPushSignChanged() called with: key = $key")
         logPushSign(sharedPreferences)
     }

--- a/xposed/src/main/java/one/yufz/hmspush/hook/system/NmsPermissionHooker.kt
+++ b/xposed/src/main/java/one/yufz/hmspush/hook/system/NmsPermissionHooker.kt
@@ -13,6 +13,7 @@ import de.robv.android.xposed.XposedHelpers.findMethodExact
 import one.yufz.hmspush.common.ANDROID_PACKAGE_NAME
 import one.yufz.hmspush.common.HMS_PACKAGE_NAME
 import one.yufz.xposed.HookCallback
+import one.yufz.xposed.HookContext
 import one.yufz.xposed.hook
 import one.yufz.xposed.hookMethod
 
@@ -98,7 +99,21 @@ object NmsPermissionHooker {
         findMethodExact(classINotificationManager, "getNotificationChannelsForPackage", String::class.java, Int::class.java, Boolean::class.java)
             .hook(hookPermission(0))
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        val deleteNotificationChannelHook: HookContext.() -> Unit = {
+            doBefore {
+                val packageName = args[0] as String
+                if (packageName != HMS_PACKAGE_NAME && Binder.getCallingUid() == Process.SYSTEM_UID) {
+                    args[1] = getPackageUid(packageName)
+                }
+            }
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            findClass("com.android.server.notification.PreferencesHelper", classINotificationManager.classLoader)
+                //public boolean deleteNotificationChannel(String pkg, int uid, String channelId, int callingUid, boolean fromSystemOrSystemUi)
+                .hookMethod("deleteNotificationChannel", String::class.java, Int::class.java, String::class.java, Int::class.java, Boolean::class.java,
+                    callback = deleteNotificationChannelHook
+                )
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             findClass("com.android.server.notification.PreferencesHelper", classINotificationManager.classLoader)
                 //public boolean deleteNotificationChannel(String pkg, int uid, String channelId)
                 .hookMethod("deleteNotificationChannel", String::class.java, Int::class.java, String::class.java) {
@@ -112,14 +127,9 @@ object NmsPermissionHooker {
         } else {
             findClass("com.android.server.notification.RankingHelper", classINotificationManager.classLoader)
                 //public void deleteNotificationChannel(String pkg, int uid, String channelId)
-                .hookMethod("deleteNotificationChannel", String::class.java, Int::class.java, String::class.java) {
-                    doBefore {
-                        val packageName = args[0] as String
-                        if (Binder.getCallingUid() == Process.SYSTEM_UID) {
-                            args[1] = getPackageUid(packageName)
-                        }
-                    }
-                }
+                .hookMethod("deleteNotificationChannel", String::class.java, Int::class.java, String::class.java,
+                    callback = deleteNotificationChannelHook
+                )
         }
 
         //void updateNotificationChannelGroupForPackage(String pkg, int uid, in NotificationChannelGroup group);


### PR DESCRIPTION
搞得
- logcat 里全是`[MiPush]  Common  forName xxx`
- lsposed log 里全是`[MiPush]  Common  forName xxx`
- lsposed log 转存上 g

太离谱了

装 release 的人绝对不需要这些

这已经糟到影响我开发了 lsposed log 都没法看了

<img width="1280" alt="image" src="https://github.com/NihilityT/MiPush/assets/39830683/2e1a8589-4d3f-476d-9d9e-1ac5973eae03">
